### PR TITLE
update grade support for android studio

### DIFF
--- a/Prj-Android/.idea/.name
+++ b/Prj-Android/.idea/.name
@@ -1,1 +1,0 @@
-Prj-Android

--- a/Prj-Android/.idea/encodings.xml
+++ b/Prj-Android/.idea/encodings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding">
-    <file url="PROJECT" charset="UTF-8" />
-  </component>
-</project>

--- a/Prj-Android/.idea/misc.xml
+++ b/Prj-Android/.idea/misc.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
@@ -42,24 +39,5 @@
   </component>
   <component name="ProjectType">
     <option name="id" value="Android" />
-  </component>
-  <component name="SvnBranchConfigurationManager">
-    <option name="mySupportsUserInfoFilter" value="true" />
-  </component>
-  <component name="masterDetails">
-    <states>
-      <state key="ProjectJDKs.UI">
-        <settings>
-          <last-edited>Android API 20 Platform</last-edited>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-    </states>
   </component>
 </project>

--- a/Prj-Android/.idea/vcs.xml
+++ b/Prj-Android/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="svn" />
-  </component>
-</project>

--- a/Prj-Android/app/build.gradle
+++ b/Prj-Android/app/build.gradle
@@ -10,41 +10,26 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
+
+        externalNativeBuild {
+            ndkBuild {
+                arguments "NDK_APPLICATION_MK:=../jni/Application.mk"
+                abiFilters "armeabi-v7a", "armeabi"
+            }
+        }
     }
+    externalNativeBuild {
+        ndkBuild {
+            path '../jni/toolchain/Android.mk'
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    sourceSets { main { jni.srcDirs = [] } }
-
-}
-tasks.withType(JavaCompile) {
-    compileTask -> compileTask.dependsOn ndkBuild
-}
-
-task ndkBuild(type: Exec) {
-    workingDir file('../jni/')
-    commandLine getNdkBuildCmd(), 'NDK_LIBS_OUT=../app/src/main/jniLibs'
-}
-
-task cleanNative(type: Exec){
-    workingDir file('../jni/')
-    commandLine getNdkBuildCmd(), 'clean'
-}
-
-clean.dependsOn cleanNative
-
-def getNdkBuildCmd() {
-    if (System.env.ANDROID_NDK_ROOT != null)
-        return System.env.ANDROID_NDK_ROOT
-    Properties properties = new Properties()
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    def ndkdir = properties.getProperty('ndk.dir', null)
-    if (ndkdir == null)
-        throw new GradleException("NDK location not found. Define location with ndk.dir in the local.properties file or with an ANDROID_NDK_ROOT environment variable.")
-    return ndkdir + "/ndk-build.cmd"
 }
 
 dependencies {

--- a/Prj-Android/build.gradle
+++ b/Prj-Android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Prj-Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Prj-Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Mon Jan 16 23:45:50 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/Prj-Android/jni/Application.mk
+++ b/Prj-Android/jni/Application.mk
@@ -1,6 +1,6 @@
 APP_BUILD_SCRIPT := $(call my-dir)/toolchain/Android.mk
 APP_MODULES := anyrtmp-jni
-APP_ABI := armeabi armeabi-v7a arm64-v8a x86
+#APP_ABI := armeabi armeabi-v7a arm64-v8a x86
 
 NDK_PATH := /cygdrive/c/Android/NDK/android-ndk-r10e
 NDK_STL_INC := $(NDK_PATH)/sources/cxx-stl/gnu-libstdc++/4.9/include

--- a/third_party/faad2-2.7/include/faad.h
+++ b/third_party/faad2-2.7/include/faad.h
@@ -29,7 +29,7 @@
 **/
 
 /* warn people for update */
-#pragma message("please update faad2 include filename and function names!")
+//#pragma message("please update faad2 include filename and function names!")
 
 /* Backwards compatible link */
 #include "neaacdec.h"


### PR DESCRIPTION
由于上个提交的疏忽导致非windows下的android grade编译不过，现重新查看android studio的grade文档，找个一个更加好的ndk集成方式，经测试mac和windows都能编译，并可以直接在android-studio中查看和编译cpp文件，建议合并和更新。